### PR TITLE
Remove semi-colons inside ~SHEET class definition in workshop.livemd

### DIFF
--- a/workshop.livemd
+++ b/workshop.livemd
@@ -374,10 +374,10 @@ You can implement modifiers as classes inside of the generated `app.swiftui.ex` 
 ```elixir
 ~SHEET"""
 "my-class" do
-  font(.title);
-  foregroundStyle(.blue);
-  frame(maxWidth: .infinity);
-  padding();
+  font(.title)
+  foregroundStyle(.blue)
+  frame(maxWidth: .infinity)
+  padding()
 end
 """
 ```


### PR DESCRIPTION
This didn't work for me with the semicolons in