### PR TITLE
Fix clearing of content field

### DIFF
--- a/workshop.livemd
+++ b/workshop.livemd
@@ -822,7 +822,7 @@ Then, add the handler for sending messages.
       socket
       |> assign(:messages, [message | socket.assigns.messages])
       # Optional: this preserves the user's name between sending messages, but clears the content field.
-      |> assign(:form, to_form(%{"name" => name}, as: "chat-form"))
+      |> assign(:form, to_form(%{"content" => ""}, as: "chat-form"))
 
     {:noreply, socket}
   end


### PR DESCRIPTION
Was running into an issue where the message content input wasn't clearing, and it seems the form assigns need to be explicitly set in order to clear the previous values.

This change explicitly sets `"content"` to `""`, and leaves `"name"` alone, which ensures the leaves the previous value as-is.